### PR TITLE
docs: add Go reference badge and normalize deprecated comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# [fetch] -- Fetch Data from URL
+# Fetch Data from URL
 
 [![ci status](https://github.com/goark/fetch/workflows/ci/badge.svg)](https://github.com/goark/fetch/actions)
 [![codeql status](https://github.com/goark/fetch/workflows/CodeQL/badge.svg)](https://github.com/goark/fetch/actions)
+[![Go Reference](https://pkg.go.dev/badge/github.com/goark/fetch.svg)](https://pkg.go.dev/github.com/goark/fetch)
 [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/goark/fetch/main/LICENSE)
 [![GitHub release](https://img.shields.io/github/release/goark/fetch.svg)](https://github.com/goark/fetch/releases/latest)
 

--- a/client.go
+++ b/client.go
@@ -43,6 +43,7 @@ func WithHTTPClient(cli *http.Client) ClientOpts {
 }
 
 // Get fetches data from URL with HTTP GET.
+//
 // Deprecated: Use GetWithContext instead.
 func (c *client) Get(u *url.URL, opts ...RequestOpts) (Response, error) {
 	return c.GetWithContext(context.Background(), u, opts...)
@@ -65,6 +66,7 @@ func (c *client) GetWithContext(ctx context.Context, u *url.URL, opts ...Request
 }
 
 // Post fetches data from URL with HTTP POST.
+//
 // Deprecated: Use PostWithContext instead.
 func (c *client) Post(u *url.URL, payload io.Reader, opts ...RequestOpts) (Response, error) {
 	return c.PostWithContext(context.Background(), u, payload, opts...)
@@ -87,6 +89,7 @@ func (c *client) PostWithContext(ctx context.Context, u *url.URL, payload io.Rea
 }
 
 // WithContext sets request context on an option-applied request.
+//
 // Deprecated: Use GetWithContext and PostWithContext instead.
 func WithContext(ctx context.Context) RequestOpts {
 	return func(req *http.Request) *http.Request {

--- a/fetch.go
+++ b/fetch.go
@@ -16,11 +16,13 @@ type RequestOpts func(*http.Request) *http.Request
 // Client represents a fetch client.
 type Client interface {
 	// Get sends a GET request.
+	//
 	// Deprecated: Use GetWithContext instead.
 	Get(u *url.URL, opts ...RequestOpts) (Response, error)
 	// GetWithContext sends a GET request with context.
 	GetWithContext(ctx context.Context, u *url.URL, opts ...RequestOpts) (Response, error)
 	// Post sends a POST request.
+	//
 	// Deprecated: Use PostWithContext instead.
 	Post(u *url.URL, payload io.Reader, opts ...RequestOpts) (Response, error)
 	// PostWithContext sends a POST request with context.


### PR DESCRIPTION
## Summary
- add Go Reference badge to `README.md`
- normalize `Deprecated:` doc comment formatting by adding a blank comment line before deprecation markers
- apply the formatting update to both interface docs and implementation docs

## Validation
- `task test` (up to date)
